### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: "*"
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/novem-code/novem-vscode/security/code-scanning/1](https://github.com/novem-code/novem-vscode/security/code-scanning/1)

To mitigate this security risk, add a `permissions` key explicitly specifying the minimal privileges needed for this workflow. The workflow does not appear to require any write permissions (it only checks out code and runs builds/tests), so `permissions: contents: read` is sufficient. This block should be added at the workflow root, above the `jobs:` key, to apply to all jobs unless otherwise overridden. No changes are needed to imports or additional definitions, just an edit to the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
