### PR TITLE
fix: propagate dark mode to webview root and react to theme toggles

### DIFF
--- a/novem_web_view/App.tsx
+++ b/novem_web_view/App.tsx
@@ -25,6 +25,13 @@ const MainContent = (props: { vsapi: VscodeApi }) => {
 
     useEffect(() => {
         enforceStyles();
+
+        const observer = new MutationObserver(() => enforceStyles());
+        observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['class'],
+        });
+        return () => observer.disconnect();
     }, []);
 
     useEffect(() => {

--- a/novem_web_view/utils.ts
+++ b/novem_web_view/utils.ts
@@ -1,7 +1,11 @@
 export const enforceStyles = () => {
     const isDark = document.body.classList.contains('vscode-dark');
 
-    // localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    if (isDark) {
+        document.documentElement.setAttribute('data-dark-mode', '');
+    } else {
+        document.documentElement.removeAttribute('data-dark-mode');
+    }
 
     const iframes = document.getElementsByTagName('iframe');
     for (const iframe of iframes) {


### PR DESCRIPTION
Set `data-dark-mode` on `document.documentElement` (not just iframes) so
vislib's mtable parent-side check passes and its iframe rule applies the
correct text color. Add a MutationObserver on `document.body`'s class to
re-run `enforceStyles` when VS Code swaps `vscode-dark` ↔ `vscode-light`.
