### PR TITLE
Harmonize right-click menus across all six resource types

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,10 +113,6 @@
                 "icon": "$(refresh)"
             },
             {
-                "command": "novem.deleteNovemGrid",
-                "title": "Delete Grid"
-            },
-            {
                 "command": "novem.createNovemDoc",
                 "title": "Create Document",
                 "icon": "$(new-folder)"
@@ -127,10 +123,6 @@
                 "icon": "$(refresh)"
             },
             {
-                "command": "novem.deleteNovemDoc",
-                "title": "Delete Document"
-            },
-            {
                 "command": "novem.createNovemPlot",
                 "title": "Create Plot",
                 "icon": "$(new-folder)"
@@ -139,10 +131,6 @@
                 "command": "novem.refreshNovemPlots",
                 "title": "Refresh Plots",
                 "icon": "$(refresh)"
-            },
-            {
-                "command": "novem.deleteNovemPlot",
-                "title": "Delete Plot"
             },
             {
                 "command": "novem.createNovemMail",
@@ -156,7 +144,11 @@
             },
             {
                 "command": "novem.sendMail",
-                "title": "Send Mail"
+                "title": "Send"
+            },
+            {
+                "command": "novem.testMail",
+                "title": "Test"
             },
             {
                 "command": "novem.createNovemJob",
@@ -169,8 +161,8 @@
                 "icon": "$(refresh)"
             },
             {
-                "command": "novem.deleteNovemJob",
-                "title": "Delete Job"
+                "command": "novem.runJob",
+                "title": "Run"
             },
             {
                 "command": "novem.createNovemRepo",
@@ -183,13 +175,22 @@
                 "icon": "$(refresh)"
             },
             {
-                "command": "novem.deleteNovemRepo",
-                "title": "Delete Repo"
+                "command": "novem.cloneNovemRepo",
+                "title": "Clone",
+                "icon": "$(repo-clone)"
             },
             {
-                "command": "novem.cloneNovemRepo",
-                "title": "Clone Repo",
-                "icon": "$(repo-clone)"
+                "command": "novem.renameResource",
+                "title": "Rename"
+            },
+            {
+                "command": "novem.deleteResource",
+                "title": "Delete"
+            },
+            {
+                "command": "novem.editResource",
+                "title": "Edit",
+                "icon": "$(edit)"
             },
             {
                 "command": "novem.login",
@@ -220,11 +221,6 @@
                 "icon": "$(refresh)"
             },
             {
-                "command": "novem.editCustomPlot",
-                "title": "Edit Custom Plot",
-                "icon": "$(edit)"
-            },
-            {
                 "command": "novem.createNodeInDirectory",
                 "title": "Create Node",
                 "icon": "$(add)"
@@ -249,80 +245,92 @@
                 {
                     "command": "novem.viewNovemPlot",
                     "when": "view == novem-plots && viewItem =~ /^plot-top/",
-                    "title": "View Plot",
+                    "title": "View",
                     "group": "0_view"
-                },
-                {
-                    "command": "novem.editCustomPlot",
-                    "when": "view == novem-plots && viewItem == plot-top-custom",
-                    "title": "Edit Custom Plot",
-                    "group": "1_show"
                 },
                 {
                     "command": "novem.viewNovemMail",
                     "when": "view == novem-mails && viewItem == mail-top",
-                    "title": "View Mail",
+                    "title": "View",
                     "group": "0_view"
-                },
-                {
-                    "command": "novem.sendMail",
-                    "when": "view == novem-mails && viewItem == mail-top",
-                    "title": "Send Mail",
-                    "group": "1_show"
                 },
                 {
                     "command": "novem.viewNovemGrid",
                     "when": "view == novem-grids && viewItem == grid-top",
-                    "title": "View Grid",
+                    "title": "View",
                     "group": "0_view"
                 },
                 {
                     "command": "novem.viewNovemDoc",
                     "when": "view == novem-docs && viewItem == doc-top",
-                    "title": "View Document",
+                    "title": "View",
                     "group": "0_view"
                 },
                 {
-                    "command": "novem.deleteNovemPlot",
-                    "when": "view == novem-plots && viewItem =~ /^plot-top/",
-                    "title": "Delete Plot",
-                    "group": "4_manipulate"
-                },
-                {
-                    "command": "novem.deleteNovemGrid",
-                    "when": "view == novem-grids && viewItem == grid-top",
-                    "title": "Delete Grid",
-                    "group": "4_manipulate"
-                },
-                {
-                    "command": "novem.deleteNovemDoc",
-                    "when": "view == novem-docs && viewItem == doc-top",
-                    "title": "Delete Document",
-                    "group": "4_manipulate"
-                },
-                {
-                    "command": "novem.deleteNovemJob",
+                    "command": "novem.runJob",
                     "when": "view == novem-jobs && viewItem == job-top",
-                    "title": "Delete Job",
-                    "group": "4_manipulate"
+                    "title": "Run",
+                    "group": "0_view"
                 },
                 {
-                    "command": "novem.deleteNovemRepo",
-                    "when": "view == novem-repos && viewItem == repo-top",
-                    "title": "Delete Repo",
-                    "group": "4_manipulate"
+                    "command": "novem.editResource",
+                    "when": "view == novem-plots && viewItem == plot-top-custom",
+                    "title": "Edit",
+                    "group": "1_show"
+                },
+                {
+                    "command": "novem.editResource",
+                    "when": "view == novem-mails && viewItem == mail-top",
+                    "title": "Edit",
+                    "group": "1_show"
+                },
+                {
+                    "command": "novem.editResource",
+                    "when": "view == novem-grids && viewItem == grid-top",
+                    "title": "Edit",
+                    "group": "1_show"
+                },
+                {
+                    "command": "novem.editResource",
+                    "when": "view == novem-docs && viewItem == doc-top",
+                    "title": "Edit",
+                    "group": "1_show"
+                },
+                {
+                    "command": "novem.testMail",
+                    "when": "view == novem-mails && viewItem == mail-top",
+                    "title": "Test",
+                    "group": "1_show"
+                },
+                {
+                    "command": "novem.sendMail",
+                    "when": "view == novem-mails && viewItem == mail-top",
+                    "title": "Send",
+                    "group": "1_show"
                 },
                 {
                     "command": "novem.cloneNovemRepo",
                     "when": "view == novem-repos && viewItem == repo-top",
-                    "title": "Clone Repo",
+                    "title": "Clone",
+                    "group": "1_show"
+                },
+                {
+                    "command": "novem.cloneNovemRepo",
+                    "when": "view == novem-repos && viewItem == repo-top",
+                    "title": "Clone",
                     "group": "inline"
                 },
                 {
-                    "command": "novem.cloneNovemRepo",
-                    "when": "view == novem-repos && viewItem == repo-top",
-                    "title": "Clone Repo",
-                    "group": "1_show"
+                    "command": "novem.renameResource",
+                    "when": "view =~ /^novem-/ && viewItem =~ /-top($|-)/",
+                    "title": "Rename",
+                    "group": "4_manipulate@1"
+                },
+                {
+                    "command": "novem.deleteResource",
+                    "when": "view =~ /^novem-/ && viewItem =~ /-top($|-)/",
+                    "title": "Delete",
+                    "group": "4_manipulate@2"
                 },
                 {
                     "command": "novem.createNodeInDirectory",
@@ -429,27 +437,31 @@
             ],
             "commandPalette": [
                 {
-                    "command": "novem.editCustomPlot",
+                    "command": "novem.renameResource",
                     "when": "false"
                 },
                 {
-                    "command": "novem.deleteNovemPlot",
+                    "command": "novem.deleteResource",
                     "when": "false"
                 },
                 {
-                    "command": "novem.deleteNovemGrid",
+                    "command": "novem.editResource",
                     "when": "false"
                 },
                 {
-                    "command": "novem.deleteNovemDoc",
+                    "command": "novem.sendMail",
                     "when": "false"
                 },
                 {
-                    "command": "novem.deleteNovemJob",
+                    "command": "novem.testMail",
                     "when": "false"
                 },
                 {
-                    "command": "novem.deleteNovemRepo",
+                    "command": "novem.runJob",
+                    "when": "false"
+                },
+                {
+                    "command": "novem.cloneNovemRepo",
                     "when": "false"
                 },
                 {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -122,19 +122,19 @@ import {
 } from './extension';
 import NovemApi from './novem-api';
 
-async function openCustomPlotFiles(plotName: string): Promise<void> {
-    const filesToOpen = [
-        { path: `/${plotName}/config/custom/custom.js`, lang: 'javascript' },
-        { path: `/${plotName}/config/custom/custom.css`, lang: 'css' },
-        { path: `/${plotName}/data`, lang: 'plaintext' },
-    ];
-    for (const file of filesToOpen) {
+interface VisFileSpec {
+    path: string;
+    lang: string;
+}
+
+async function openVisFiles(visType: string, files: VisFileSpec[]): Promise<void> {
+    for (const file of files) {
         try {
             await vscode.commands.executeCommand(
                 'novem.openFile',
                 vscode.Uri.from({
                     scheme: 'novem',
-                    authority: 'plots',
+                    authority: visType,
                     path: file.path,
                 }),
                 'file',
@@ -144,6 +144,61 @@ async function openCustomPlotFiles(plotName: string): Promise<void> {
             // File may not exist — skip silently
         }
     }
+}
+
+async function openCustomPlotFiles(plotName: string): Promise<void> {
+    await openVisFiles('plots', [
+        { path: `/${plotName}/config/custom/custom.js`, lang: 'javascript' },
+        { path: `/${plotName}/config/custom/custom.css`, lang: 'css' },
+        { path: `/${plotName}/data`, lang: 'plaintext' },
+    ]);
+}
+
+// Per-type singular nouns used in confirmation prompts and notifications.
+const NOUNS: Record<string, string> = {
+    plots: 'plot',
+    mails: 'mail',
+    grids: 'grid',
+    docs: 'document',
+    jobs: 'job',
+    repos: 'repo',
+};
+
+// Files that "Edit" opens for each resource. Plots are special — the spec
+// depends on plot type (only custom has editable JS/CSS), so they are dispatched
+// inline in editResource instead.
+const EDIT_FILES: Record<string, (name: string) => VisFileSpec[]> = {
+    mails: name => [{ path: `/${name}/content`, lang: 'nv_markdown' }],
+    docs: name => [{ path: `/${name}/content`, lang: 'nv_markdown' }],
+    grids: name => [
+        { path: `/${name}/layout`, lang: 'nv_markdown' },
+        { path: `/${name}/mapping`, lang: 'nv_markdown' },
+    ],
+};
+
+interface RecipientCounts {
+    to: number;
+    cc: number;
+    bcc: number;
+}
+
+// Mail recipient fields are newline-separated text. A missing field (404)
+// surfaces as undefined from readFile and means "no recipients of that kind".
+async function countMailRecipients(api: NovemApi, mailName: string): Promise<RecipientCounts> {
+    const countField = async (field: 'to' | 'cc' | 'bcc'): Promise<number> => {
+        const content = await api.readFile('mails', `/${mailName}/recipients/${field}`);
+        if (!content || typeof content !== 'string') return 0;
+        return content
+            .split('\n')
+            .map(s => s.trim())
+            .filter(s => s.length > 0).length;
+    };
+    const [to, cc, bcc] = await Promise.all([
+        countField('to'),
+        countField('cc'),
+        countField('bcc'),
+    ]);
+    return { to, cc, bcc };
 }
 
 async function closeEditorsForItem(visType: string, itemName: string): Promise<void> {
@@ -171,6 +226,26 @@ async function promptForId(
         prompt,
         placeHolder: placeholder,
         validateInput: (inputValue: string) => (!pattern.test(inputValue) ? message : undefined),
+    });
+}
+
+async function promptForRename(currentName: string, visType: string): Promise<string | undefined> {
+    // Jobs and repos accept hyphens in IDs; visualisations don't. Mirror the
+    // create-prompt validation so a rename can't produce an ID the API would
+    // later reject.
+    const allowHyphens = visType === 'jobs' || visType === 'repos';
+    const pattern = allowHyphens ? /^[a-z0-9_-]+$/ : /^[a-z0-9_]+$/;
+    const message = allowHyphens
+        ? 'Only lowercase ASCII characters, underscores, and hyphens are allowed!'
+        : 'Only lowercase ASCII characters and underscores are allowed!';
+    return vscode.window.showInputBox({
+        prompt: `Rename "${currentName}" to:`,
+        value: currentName,
+        validateInput: (inputValue: string) => {
+            if (!pattern.test(inputValue)) return message;
+            if (inputValue === currentName) return 'New name must differ from current name';
+            return undefined;
+        },
     });
 }
 
@@ -546,22 +621,6 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
     );
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('novem.deleteNovemPlot', async (item: MyTreeItem) => {
-            if (!(await confirmDeletion(item.name, 'visualisation'))) return;
-            await api.deletePlot(item.name);
-            await closeEditorsForItem('plots', item.name);
-            vscode.window.showWarningMessage(`Deleted "${item.name}"`);
-            item.parent.refresh();
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('novem.editCustomPlot', async (item: MyTreeItem) => {
-            await openCustomPlotFiles(item.name);
-        }),
-    );
-
-    context.subscriptions.push(
         vscode.commands.registerCommand('novem.refreshNovemPlots', async () => {
             plotsProvider.refresh();
         }),
@@ -596,16 +655,6 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
     );
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('novem.deleteNovemGrid', async (item: MyTreeItem) => {
-            if (!(await confirmDeletion(item.name, 'grid'))) return;
-            await api.deleteGrid(item.name);
-            await closeEditorsForItem('grids', item.name);
-            vscode.window.showWarningMessage(`Deleted "${item.name}"`);
-            item.parent.refresh();
-        }),
-    );
-
-    context.subscriptions.push(
         vscode.commands.registerCommand('novem.refreshNovemGrids', async () => {
             gridsProvider.refresh();
         }),
@@ -630,16 +679,6 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
             docsProvider.refresh();
 
             vscode.window.showInformationMessage(`New document ${docId} created`);
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('novem.deleteNovemDoc', async (item: MyTreeItem) => {
-            if (!(await confirmDeletion(item.name, 'document'))) return;
-            await api.deleteDoc(item.name);
-            await closeEditorsForItem('docs', item.name);
-            vscode.window.showWarningMessage(`Deleted "${item.name}"`);
-            item.parent.refresh();
         }),
     );
 
@@ -676,16 +715,6 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
     );
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('novem.deleteNovemJob', async (item: MyTreeItem) => {
-            if (!(await confirmDeletion(item.name, 'job'))) return;
-            await api.deleteJob(item.name);
-            await closeEditorsForItem('jobs', item.name);
-            vscode.window.showWarningMessage(`Deleted "${item.name}"`);
-            item.parent.refresh();
-        }),
-    );
-
-    context.subscriptions.push(
         vscode.commands.registerCommand('novem.refreshNovemJobs', async () => {
             jobsProvider?.refresh();
         }),
@@ -714,16 +743,6 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
             reposProvider?.refresh();
 
             vscode.window.showInformationMessage(`New repo ${repoId} created`);
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('novem.deleteNovemRepo', async (item: MyTreeItem) => {
-            if (!(await confirmDeletion(item.name, 'repo'))) return;
-            await api.deleteRepo(item.name);
-            await closeEditorsForItem('repos', item.name);
-            vscode.window.showWarningMessage(`Deleted "${item.name}"`);
-            item.parent.refresh();
         }),
     );
 
@@ -914,6 +933,126 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
                     `Failed to delete ${itemType} "${item.name}": ${error}`,
                 );
             }
+        }),
+    );
+
+    // Unified top-level resource verbs: rename / delete / edit dispatch on
+    // item.visType, replacing the per-type deleteNovem* / editCustomPlot
+    // commands that previously duplicated this logic six ways.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('novem.renameResource', async (item: MyTreeItem) => {
+            const noun = NOUNS[item.visType] ?? 'resource';
+            const newName = await promptForRename(item.name, item.visType);
+            if (!newName) return;
+            try {
+                await api.renameResource(item.visType, item.name, newName);
+            } catch (error) {
+                console.error('Error renaming resource:', error);
+                vscode.window.showErrorMessage(`Failed to rename ${noun} "${item.name}": ${error}`);
+                return;
+            }
+            await closeEditorsForItem(item.visType, item.name);
+            vscode.window.showInformationMessage(`Renamed ${noun} "${item.name}" to "${newName}"`);
+            item.parent.refresh();
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('novem.deleteResource', async (item: MyTreeItem) => {
+            const noun = NOUNS[item.visType] ?? 'resource';
+            if (!(await confirmDeletion(item.name, noun))) return;
+            try {
+                await api.deleteResource(item.visType, item.name);
+            } catch (error) {
+                console.error('Error deleting resource:', error);
+                vscode.window.showErrorMessage(`Failed to delete ${noun} "${item.name}": ${error}`);
+                return;
+            }
+            await closeEditorsForItem(item.visType, item.name);
+            vscode.window.showWarningMessage(`Deleted "${item.name}"`);
+            item.parent.refresh();
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('novem.editResource', async (item: MyTreeItem) => {
+            // Plots are special: only "custom" plots have editable JS/CSS, so
+            // the file set depends on the plot kind (carried on iconType).
+            if (item.visType === 'plots') {
+                if (item.iconType === 'custom') {
+                    await openCustomPlotFiles(item.name);
+                }
+                return;
+            }
+            const builder = EDIT_FILES[item.visType];
+            if (!builder) return;
+            await openVisFiles(item.visType, builder(item.name));
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('novem.sendMail', async (item: MyTreeItem) => {
+            let counts: RecipientCounts;
+            try {
+                counts = await countMailRecipients(api, item.name);
+            } catch (error) {
+                console.error('Error fetching mail recipients:', error);
+                vscode.window.showErrorMessage(
+                    `Failed to read recipients for "${item.name}": ${error}`,
+                );
+                return;
+            }
+            const total = counts.to + counts.cc + counts.bcc;
+            if (total === 0) {
+                vscode.window.showWarningMessage(
+                    `"${item.name}" has no recipients — set to / cc / bcc before sending.`,
+                );
+                return;
+            }
+            const noun = total === 1 ? 'recipient' : 'recipients';
+            const confirm = await vscode.window.showWarningMessage(
+                `Send "${item.name}" to ${total} ${noun}.`,
+                {
+                    modal: true,
+                    detail: `To: ${counts.to}, cc: ${counts.cc}, bcc: ${counts.bcc}`,
+                },
+                'Send',
+            );
+            if (confirm !== 'Send') return;
+            try {
+                await api.sendMail(item.name);
+            } catch (error) {
+                console.error('Error sending mail:', error);
+                vscode.window.showErrorMessage(`Failed to send mail "${item.name}": ${error}`);
+                return;
+            }
+            vscode.window.showInformationMessage(`Mail "${item.name}" queued for sending`);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('novem.testMail', async (item: MyTreeItem) => {
+            try {
+                await api.testMail(item.name);
+            } catch (error) {
+                console.error('Error sending test mail:', error);
+                vscode.window.showErrorMessage(`Failed to send test mail "${item.name}": ${error}`);
+                return;
+            }
+            vscode.window.showInformationMessage(`Test mail "${item.name}" sent to your address`);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('novem.runJob', async (item: MyTreeItem) => {
+            try {
+                await api.runJob(item.name);
+            } catch (error) {
+                console.error('Error running job:', error);
+                vscode.window.showErrorMessage(`Failed to run job "${item.name}": ${error}`);
+                return;
+            }
+            vscode.window.showInformationMessage(`Job "${item.name}" triggered`);
         }),
     );
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -176,29 +176,84 @@ const EDIT_FILES: Record<string, (name: string) => VisFileSpec[]> = {
     ],
 };
 
-interface RecipientCounts {
-    to: number;
-    cc: number;
-    bcc: number;
+export interface RecipientField {
+    groups: string[];
+    addresses: string[];
+}
+
+export interface RecipientSummary {
+    to: RecipientField;
+    cc: RecipientField;
+    bcc: RecipientField;
+}
+
+// Entries prefixed with '+' are org- or user-groups that expand server-side
+// (e.g. '+dnb~all_hands'). Their real member count isn't knowable from here,
+// so we surface them as a distinct class instead of pretending each is one
+// "recipient".
+export function classifyRecipientField(raw: string | undefined | null): RecipientField {
+    if (!raw || typeof raw !== 'string') return { groups: [], addresses: [] };
+    const groups: string[] = [];
+    const addresses: string[] = [];
+    for (const entry of raw.split('\n').map(s => s.trim()).filter(s => s.length > 0)) {
+        if (entry.startsWith('+')) groups.push(entry);
+        else addresses.push(entry);
+    }
+    return { groups, addresses };
 }
 
 // Mail recipient fields are newline-separated text. A missing field (404)
 // surfaces as undefined from readFile and means "no recipients of that kind".
-async function countMailRecipients(api: NovemApi, mailName: string): Promise<RecipientCounts> {
-    const countField = async (field: 'to' | 'cc' | 'bcc'): Promise<number> => {
+async function readMailRecipients(api: NovemApi, mailName: string): Promise<RecipientSummary> {
+    const read = async (field: 'to' | 'cc' | 'bcc'): Promise<RecipientField> => {
         const content = await api.readFile('mails', `/${mailName}/recipients/${field}`);
-        if (!content || typeof content !== 'string') return 0;
-        return content
-            .split('\n')
-            .map(s => s.trim())
-            .filter(s => s.length > 0).length;
+        return classifyRecipientField(content as string | null | undefined);
     };
-    const [to, cc, bcc] = await Promise.all([
-        countField('to'),
-        countField('cc'),
-        countField('bcc'),
-    ]);
+    const [to, cc, bcc] = await Promise.all([read('to'), read('cc'), read('bcc')]);
     return { to, cc, bcc };
+}
+
+function pluralize(n: number, singular: string, plural: string): string {
+    return `${n} ${n === 1 ? singular : plural}`;
+}
+
+export function recipientTotals(summary: RecipientSummary): {
+    groups: number;
+    addresses: number;
+    entries: number;
+} {
+    const fields = [summary.to, summary.cc, summary.bcc];
+    const groups = fields.reduce((n, f) => n + f.groups.length, 0);
+    const addresses = fields.reduce((n, f) => n + f.addresses.length, 0);
+    return { groups, addresses, entries: groups + addresses };
+}
+
+export function recipientSummaryTitle(name: string, summary: RecipientSummary): string {
+    const { groups, addresses, entries } = recipientTotals(summary);
+    if (groups === 0) {
+        return `Send "${name}" to ${pluralize(addresses, 'address', 'addresses')}.`;
+    }
+    if (addresses === 0) {
+        return `Send "${name}" to ${pluralize(groups, 'group', 'groups')}.`;
+    }
+    return (
+        `Send "${name}" to ${pluralize(entries, 'entry', 'entries')} ` +
+        `(${pluralize(addresses, 'address', 'addresses')}, ` +
+        `${pluralize(groups, 'group', 'groups')}).`
+    );
+}
+
+export function recipientSummaryDetail(summary: RecipientSummary): string {
+    const lines: string[] = [];
+    const formatField = (label: string, field: RecipientField): void => {
+        const all = [...field.addresses, ...field.groups];
+        if (all.length === 0) return;
+        lines.push(`${label}: ${all.join(', ')}`);
+    };
+    formatField('To', summary.to);
+    formatField('Cc', summary.cc);
+    formatField('Bcc', summary.bcc);
+    return lines.join('\n');
 }
 
 async function closeEditorsForItem(visType: string, itemName: string): Promise<void> {
@@ -992,9 +1047,9 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('novem.sendMail', async (item: MyTreeItem) => {
-            let counts: RecipientCounts;
+            let summary: RecipientSummary;
             try {
-                counts = await countMailRecipients(api, item.name);
+                summary = await readMailRecipients(api, item.name);
             } catch (error) {
                 console.error('Error fetching mail recipients:', error);
                 vscode.window.showErrorMessage(
@@ -1002,19 +1057,17 @@ export function setupCommands(context: vscode.ExtensionContext, api: NovemApi) {
                 );
                 return;
             }
-            const total = counts.to + counts.cc + counts.bcc;
-            if (total === 0) {
+            if (recipientTotals(summary).entries === 0) {
                 vscode.window.showWarningMessage(
                     `"${item.name}" has no recipients — set to / cc / bcc before sending.`,
                 );
                 return;
             }
-            const noun = total === 1 ? 'recipient' : 'recipients';
             const confirm = await vscode.window.showWarningMessage(
-                `Send "${item.name}" to ${total} ${noun}.`,
+                recipientSummaryTitle(item.name, summary),
                 {
                     modal: true,
-                    detail: `To: ${counts.to}, cc: ${counts.cc}, bcc: ${counts.bcc}`,
+                    detail: recipientSummaryDetail(summary),
                 },
                 'Send',
             );

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -195,7 +195,10 @@ export function classifyRecipientField(raw: string | undefined | null): Recipien
     if (!raw || typeof raw !== 'string') return { groups: [], addresses: [] };
     const groups: string[] = [];
     const addresses: string[] = [];
-    for (const entry of raw.split('\n').map(s => s.trim()).filter(s => s.length > 0)) {
+    for (const entry of raw
+        .split('\n')
+        .map(s => s.trim())
+        .filter(s => s.length > 0)) {
         if (entry.startsWith('+')) groups.push(entry);
         else addresses.push(entry);
     }
@@ -243,12 +246,22 @@ export function recipientSummaryTitle(name: string, summary: RecipientSummary): 
     );
 }
 
+const RECIPIENT_PREVIEW_LIMIT = 10;
+
 export function recipientSummaryDetail(summary: RecipientSummary): string {
     const lines: string[] = [];
     const formatField = (label: string, field: RecipientField): void => {
-        const all = [...field.addresses, ...field.groups];
+        // Groups first in the preview: they're the high-leverage class, so
+        // capping the list shouldn't hide them behind a wall of addresses.
+        const all = [...field.groups, ...field.addresses];
         if (all.length === 0) return;
-        lines.push(`${label}: ${all.join(', ')}`);
+        if (all.length <= RECIPIENT_PREVIEW_LIMIT) {
+            lines.push(`${label}: ${all.join(', ')}`);
+            return;
+        }
+        const shown = all.slice(0, RECIPIENT_PREVIEW_LIMIT).join(', ');
+        const more = all.length - RECIPIENT_PREVIEW_LIMIT;
+        lines.push(`${label}: ${shown}, …and ${more} more`);
     };
     formatField('To', summary.to);
     formatField('Cc', summary.cc);

--- a/src/novem-api.ts
+++ b/src/novem-api.ts
@@ -79,7 +79,7 @@ export default class NovemApi {
     }
 
     private async makeRequest<T = any>(
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+        method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
         url: string,
         options: {
             body?: any;
@@ -127,10 +127,16 @@ export default class NovemApi {
             }
         }
 
+        // Mutating endpoints (PATCH rename, POST /status, DELETE) often reply
+        // with HTTP 2xx and an empty body. Treat that as a successful response
+        // with no payload rather than failing on JSON.parse('').
+        const text = await response.text();
+        if (text.length === 0) {
+            return undefined as T;
+        }
         try {
-            return (await response.json()) as T;
+            return JSON.parse(text) as T;
         } catch (error) {
-            const text = await response.text().catch(() => '[Unable to read response]');
             console.error(
                 `JSON parsing error for ${url}:`,
                 error,
@@ -156,6 +162,13 @@ export default class NovemApi {
 
     private async put(url: string, data: any) {
         return this.makeRequest('PUT', url, { body: data });
+    }
+
+    private async patch(url: string, data: string, headers?: Record<string, string>) {
+        return this.makeRequest('PATCH', url, {
+            body: data,
+            headers: headers ?? { 'Content-Type': 'text/plain' },
+        });
     }
 
     private async delete(url: string) {
@@ -347,24 +360,37 @@ export default class NovemApi {
         else return await this.get(`${this.apiRoot}/code/repos/${repoId}`);
     }
 
-    async deletePlot(plotId: string) {
-        return await this.delete(`${this.apiRoot}/vis/plots/${plotId}`);
+    async deleteResource(visType: string, id: string) {
+        return await this.delete(`${this.apiRoot}${visTypePath(visType)}/${id}`);
     }
 
-    async deleteGrid(gridId: string) {
-        return await this.delete(`${this.apiRoot}/vis/grids/${gridId}`);
+    /**
+     * Rename a resource by PATCH-ing its top-level URI with the new name as
+     * a text/plain body. Mirrors the rename verb used by novem-tui.
+     */
+    async renameResource(visType: string, id: string, newName: string) {
+        return await this.patch(`${this.apiRoot}${visTypePath(visType)}/${id}`, newName);
     }
 
-    async deleteDoc(docId: string) {
-        return await this.delete(`${this.apiRoot}/vis/docs/${docId}`);
+    /** POST /status=sending to trigger an actual mail send. */
+    async sendMail(mailId: string) {
+        return await this.post(`${this.apiRoot}/vis/mails/${mailId}/status`, 'sending', {
+            'Content-Type': 'text/plain',
+        });
     }
 
-    async deleteJob(jobId: string) {
-        return await this.delete(`${this.apiRoot}/code/jobs/${jobId}`);
+    /** POST /status=testing to send the mail to its creator as a preview. */
+    async testMail(mailId: string) {
+        return await this.post(`${this.apiRoot}/vis/mails/${mailId}/status`, 'testing', {
+            'Content-Type': 'text/plain',
+        });
     }
 
-    async deleteRepo(repoId: string) {
-        return await this.delete(`${this.apiRoot}/code/repos/${repoId}`);
+    /** POST /data={} to trigger a job run. */
+    async runJob(jobId: string) {
+        return await this.post(`${this.apiRoot}/code/jobs/${jobId}/data`, '{}', {
+            'Content-Type': 'application/json',
+        });
     }
 
     async readFile(visType: string, path: string) {

--- a/src/test/suite/novem-api.test.ts
+++ b/src/test/suite/novem-api.test.ts
@@ -6,6 +6,7 @@ interface CapturedCall {
     url: string;
     method?: string;
     body?: unknown;
+    headers?: Record<string, string>;
 }
 
 let calls: CapturedCall[];
@@ -16,9 +17,9 @@ function installFakeFetch(jsonValue: unknown = []) {
     originalFetch = globalThis.fetch;
     (globalThis as { fetch: unknown }).fetch = async (
         url: string,
-        opts: { method?: string; body?: unknown } = {},
+        opts: { method?: string; body?: unknown; headers?: Record<string, string> } = {},
     ) => {
-        calls.push({ url, method: opts.method, body: opts.body });
+        calls.push({ url, method: opts.method, body: opts.body, headers: opts.headers });
         return {
             ok: true,
             status: 200,
@@ -26,6 +27,29 @@ function installFakeFetch(jsonValue: unknown = []) {
             json: async () => jsonValue,
             text: async () =>
                 typeof jsonValue === 'string' ? jsonValue : JSON.stringify(jsonValue),
+        } as unknown as Response;
+    };
+}
+
+// Mutating endpoints often respond with HTTP 2xx and an empty body. The
+// makeRequest helper used to JSON.parse('') and throw; we now treat empty
+// bodies as "no payload". This helper lets tests reproduce that response.
+function installEmptyBodyFetch() {
+    calls = [];
+    originalFetch = globalThis.fetch;
+    (globalThis as { fetch: unknown }).fetch = async (
+        url: string,
+        opts: { method?: string; body?: unknown; headers?: Record<string, string> } = {},
+    ) => {
+        calls.push({ url, method: opts.method, body: opts.body, headers: opts.headers });
+        return {
+            ok: true,
+            status: 204,
+            statusText: 'No Content',
+            json: async () => {
+                throw new SyntaxError('Unexpected end of JSON input');
+            },
+            text: async () => '',
         } as unknown as Response;
     };
 }
@@ -108,12 +132,12 @@ suite('NovemApi grid/doc endpoints', () => {
         assert.strictEqual(calls[1].method, 'PUT');
     });
 
-    test('deleteGrid / deleteDoc DELETE the right path', async () => {
-        await api.deleteGrid('g1');
+    test('deleteResource DELETEs grids and docs at the right path', async () => {
+        await api.deleteResource('grids', 'g1');
         assert.strictEqual(calls[0].url, `${API_ROOT}/vis/grids/g1`);
         assert.strictEqual(calls[0].method, 'DELETE');
 
-        await api.deleteDoc('d1');
+        await api.deleteResource('docs', 'd1');
         assert.strictEqual(calls[1].url, `${API_ROOT}/vis/docs/d1`);
         assert.strictEqual(calls[1].method, 'DELETE');
     });
@@ -225,5 +249,87 @@ suite('NovemApi GraphQL aggregate', () => {
             'fell back to REST /u/sen/p',
         );
         assert.deepStrictEqual(agg.plots, []);
+    });
+});
+
+suite('NovemApi resource-action endpoints', () => {
+    let api: NovemApi;
+
+    setup(() => {
+        installFakeFetch([]);
+        api = new NovemApi(API_ROOT, 'test-token');
+    });
+    teardown(() => restoreFetch());
+
+    // Walk every visType so a future addition (or removal) to VIS_TYPE_PREFIX
+    // can't quietly skip a type. Each pair drives one rename + one delete call.
+    const visTypes: Array<[string, string]> = [
+        ['plots', '/vis/plots'],
+        ['mails', '/vis/mails'],
+        ['grids', '/vis/grids'],
+        ['docs', '/vis/docs'],
+        ['jobs', '/code/jobs'],
+        ['repos', '/code/repos'],
+    ];
+
+    for (const [visType, prefix] of visTypes) {
+        test(`renameResource PATCHes ${visType} as text/plain`, async () => {
+            await api.renameResource(visType, 'old_id', 'new_id');
+            assert.strictEqual(calls[0].url, `${API_ROOT}${prefix}/old_id`);
+            assert.strictEqual(calls[0].method, 'PATCH');
+            assert.strictEqual(calls[0].body, 'new_id');
+            assert.strictEqual(calls[0].headers?.['Content-Type'], 'text/plain');
+        });
+
+        test(`deleteResource DELETEs ${visType}/<id>`, async () => {
+            await api.deleteResource(visType, 'x');
+            assert.strictEqual(calls[0].url, `${API_ROOT}${prefix}/x`);
+            assert.strictEqual(calls[0].method, 'DELETE');
+        });
+    }
+
+    test('sendMail POSTs /status=sending', async () => {
+        await api.sendMail('demo');
+        assert.strictEqual(calls[0].url, `${API_ROOT}/vis/mails/demo/status`);
+        assert.strictEqual(calls[0].method, 'POST');
+        assert.strictEqual(calls[0].body, 'sending');
+        assert.strictEqual(calls[0].headers?.['Content-Type'], 'text/plain');
+    });
+
+    test('testMail POSTs /status=testing', async () => {
+        await api.testMail('demo');
+        assert.strictEqual(calls[0].url, `${API_ROOT}/vis/mails/demo/status`);
+        assert.strictEqual(calls[0].method, 'POST');
+        assert.strictEqual(calls[0].body, 'testing');
+        assert.strictEqual(calls[0].headers?.['Content-Type'], 'text/plain');
+    });
+
+    test('runJob POSTs /data with an empty JSON body', async () => {
+        await api.runJob('my_job');
+        assert.strictEqual(calls[0].url, `${API_ROOT}/code/jobs/my_job/data`);
+        assert.strictEqual(calls[0].method, 'POST');
+        assert.strictEqual(calls[0].body, '{}');
+        assert.strictEqual(calls[0].headers?.['Content-Type'], 'application/json');
+    });
+});
+
+suite('NovemApi empty-body tolerance', () => {
+    // Regression: PATCH and POST against the Novem API often return HTTP 2xx
+    // with an empty body. makeRequest used to JSON.parse('') and throw
+    // "Unexpected end of JSON input"; it should now resolve to undefined.
+    teardown(() => restoreFetch());
+
+    test('rename succeeds when the server returns an empty 2xx body', async () => {
+        installEmptyBodyFetch();
+        const api = new NovemApi(API_ROOT, 'tok');
+        const result = await api.renameResource('mails', 'old', 'new');
+        assert.strictEqual(result, undefined);
+    });
+
+    test('sendMail succeeds when the server returns an empty 2xx body', async () => {
+        installEmptyBodyFetch();
+        const api = new NovemApi(API_ROOT, 'tok');
+        const result = await api.sendMail('demo');
+        assert.strictEqual(result, undefined);
     });
 });


### PR DESCRIPTION
## Summary

- Top-level resources (plots / mails / grids / docs / jobs / repos) exposes same verbs in same order: **View** or **Run** (`0_view`), **Edit / Test / Send / Clone** (`1_show`), **Rename / Delete** (`4_manipulate`).
- Per-type `deleteNovem*` and `editCustomPlot` commands collapse into generic `novem.{rename,delete,edit}Resource` handlers that dispatch on `item.visType`. Send/Test (mail) and Run (job) get dedicated commands.
- `Send` mail shows a modal confirm: *"Send "X" to N recipients. To: a, cc: b, bcc: c."* 
- **Bug fix:** `makeRequest` used to `JSON.parse('')` and throw on HTTP 2xx responses with empty bodies. Now resolves to `undefined`.
- 17 new tests covering rename / send / test / run / delete URL + method + body + content-type across all six visTypes, plus regression tests for the empty-body fix. **71 passing** (was 54).

## Test plan

- [x] `npm run compile`, `npm run lint`, `npm test` all green
- [x] Manually verified rename, delete, send (with recipient modal), test, run, and edit (custom plot, grid, doc, mail) against the real Novem API on the `trt` profile
- [ ] Reviewer to sanity-check the menu ordering by right-clicking one resource of each type in a fresh Extension Development Host