### PR TITLE
README sweep: match current functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # novem - datavisualisation in your editor
 
-[novem](https://novem.io/) is a datavisualisation platform for coders, create
+[novem](https://novem.io/) is a datavisualisation platform for coders – create
 charts, documents, emails and reports right from your code. With novem for VS
-Code you can browse, create, edit and preview everything on your novem account
-without leaving the editor.
+Code you can browse, edit and preview your novem visuals from your editor.
 
 ![email example](./img/mail_example.png)
 
@@ -22,53 +21,48 @@ ext install novem.novem-vscode
 
 ## Getting started
 
-All you need is a [novem account](https://novem.io/) — the extension handles
-sign-in itself. Open the novem bar in the activity bar and click **Sign in to
-Novem** (or run `novem: Login` from the command palette), then complete the
-login in your browser.
+You'll need a valid novem account. To sign in, open the novem bar in the
+activity bar and click "Sign in to Novem", or run `novem: Login` from the
+command palette. The login itself happens in your browser.
 
 If you already use the novem CLI or one of the novem libraries, the extension
-picks up your existing configuration and you're signed in from the start.
+reads the same configuration and no separate sign-in is needed.
 
 ## Profiles
 
-You can be signed in to several accounts — or several environments — at once,
-each stored as a profile in the shared novem configuration:
+The novem configuration can hold several profiles, for example for separate
+accounts or environments:
 
--   `novem: Login New Profile` signs in with another account and saves it as a
-    new profile
+-   `novem: Login New Profile` signs in with another account and saves it as
+    a new profile
 -   `novem: Select Profile` switches the active profile
--   `novem: Edit Config File` opens the configuration for manual fine-tuning
+-   `novem: Edit Config File` opens the configuration file for manual editing
 
-All of these are available from the command palette and from the `⋯` menu on
-the novem views.
+These commands are available from the command palette and from the `⋯` menu
+on the novem views.
 
 ## Working with your visuals
 
-The novem bar lists everything on your account across six resource types:
-**plots**, **e-mails**, **grids**, **documents**, **jobs** and **repos** (the
-last two appear once your account has any).
+The novem bar lists the resources on your account, grouped into plots,
+e-mails, grids, documents, jobs and repos.
 
-Every view has a `+` button for creating new resources, and the right-click
+Each view has a `+` button for creating new resources, and the right-click
 menu lets you view, edit, rename and delete existing ones. Some resource
-types have extra actions:
+types have additional actions:
 
--   **E-mails** can be tested and sent: _Test_ delivers the mail to your own
-    address, _Send_ shows a recipient summary for confirmation before mailing
-    everyone on the to/cc/bcc lists.
--   **Jobs** can be run directly from the tree.
--   **Repos** can be cloned to your machine.
+-   E-mails can be tested and sent. `Test` delivers the mail to your own
+    address; `Send` shows a summary of the to/cc/bcc lists and asks for
+    confirmation first.
+-   Jobs can be run.
+-   Repos can be cloned to your machine.
 
 ## Editing and previews
 
-Expanding a resource in the tree exposes its files. They are read straight
-from the novem API and written back when you save — no local checkout, your
-changes are live the moment you hit save.
+Expanding a resource in the tree shows its files. These are read from the
+novem API and written back when you save; there is no local copy.
 
-_View_ opens a live preview of a plot, e-mail, grid or document in an editor
-tab, so you can keep the content on one side and the rendered result on the
-other.
+View opens a preview of a plot, e-mail, grid or document in an editor tab.
 
-Content files (e-mail and document content, grid layouts and mappings) get
-novem-flavoured markdown highlighting out of the box, and the same
-`nv_markdown` syntax is available for local `.nvm` and `.nvmd` files.
+Content files (e-mail and document content, grid layouts and mappings) are
+highlighted as nv_markdown, a markdown variant with novem extensions. The
+same highlighting applies to local `.nvm` and `.nvmd` files.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # novem - datavisualisation in your editor
-[novem](https://novem.io/) is a datavisualisation platform for coders, create charts, documents, emails and reports right from your code. With novem for vs code you can now edit and preview all your novem visuals with your favourite tool.
 
+[novem](https://novem.io/) is a datavisualisation platform for coders, create
+charts, documents, emails and reports right from your code. With novem for VS
+Code you can browse, create, edit and preview everything on your novem account
+without leaving the editor.
+
+![email example](./img/mail_example.png)
 
 ## Installation
 
@@ -8,20 +13,62 @@ Install through VS Code extensions. Search for `novem`
 
 [Visual Studio Code Market Place: novem](https://marketplace.visualstudio.com/items?itemName=novem.novem-vscode)
 
-Can also be installed in VS Code: Launch VS Code Quick Open (Ctrl+P), paste the following command, and press enter.
+Can also be installed in VS Code: Launch VS Code Quick Open (Ctrl+P), paste
+the following command, and press enter.
 
 ```
 ext install novem.novem-vscode
 ```
 
 ## Getting started
-You'll need a valid novem account and to have setup a novem configuration on your system.
 
-```
-pip install novem
-novem --init
-```
-## Editing your visuals
-Navigate through and open the relevant visuals using the novem bar and everything should work just like normal.
+All you need is a [novem account](https://novem.io/) — the extension handles
+sign-in itself. Open the novem bar in the activity bar and click **Sign in to
+Novem** (or run `novem: Login` from the command palette), then complete the
+login in your browser.
 
-![email example](./img/mail_example.png)
+If you already use the novem CLI or one of the novem libraries, the extension
+picks up your existing configuration and you're signed in from the start.
+
+## Profiles
+
+You can be signed in to several accounts — or several environments — at once,
+each stored as a profile in the shared novem configuration:
+
+-   `novem: Login New Profile` signs in with another account and saves it as a
+    new profile
+-   `novem: Select Profile` switches the active profile
+-   `novem: Edit Config File` opens the configuration for manual fine-tuning
+
+All of these are available from the command palette and from the `⋯` menu on
+the novem views.
+
+## Working with your visuals
+
+The novem bar lists everything on your account across six resource types:
+**plots**, **e-mails**, **grids**, **documents**, **jobs** and **repos** (the
+last two appear once your account has any).
+
+Every view has a `+` button for creating new resources, and the right-click
+menu lets you view, edit, rename and delete existing ones. Some resource
+types have extra actions:
+
+-   **E-mails** can be tested and sent: _Test_ delivers the mail to your own
+    address, _Send_ shows a recipient summary for confirmation before mailing
+    everyone on the to/cc/bcc lists.
+-   **Jobs** can be run directly from the tree.
+-   **Repos** can be cloned to your machine.
+
+## Editing and previews
+
+Expanding a resource in the tree exposes its files. They are read straight
+from the novem API and written back when you save — no local checkout, your
+changes are live the moment you hit save.
+
+_View_ opens a live preview of a plot, e-mail, grid or document in an editor
+tab, so you can keep the content on one side and the rendered result on the
+other.
+
+Content files (e-mail and document content, grid layouts and mappings) get
+novem-flavoured markdown highlighting out of the box, and the same
+`nv_markdown` syntax is available for local `.nvm` and `.nvmd` files.

--- a/package.json
+++ b/package.json
@@ -523,12 +523,12 @@
                 {
                     "id": "novem-jobs",
                     "name": "Jobs",
-                    "when": "novem.loggedIn && novem.hasJobs"
+                    "when": "novem.loggedIn"
                 },
                 {
                     "id": "novem-repos",
                     "name": "Repos",
-                    "when": "novem.loggedIn && novem.hasRepos"
+                    "when": "novem.loggedIn"
                 },
                 {
                     "id": "novem-login",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,8 +210,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
     primeProviderRootItems(jobsRootPromise, jobsProvider);
     primeProviderRootItems(reposRootPromise, reposProvider);
-    vscode.commands.executeCommand('setContext', 'novem.hasJobs', true);
-    vscode.commands.executeCommand('setContext', 'novem.hasRepos', true);
 
     const sbi = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
 


### PR DESCRIPTION
Refs #107 (one checklist item left open — see below)

## What changed

Full rewrite of the README against the actual extension surface (package.json contributions + src):

- **Getting started** now describes the built-in OAuth sign-in (novem bar **Sign in to Novem** / `novem: Login`, browser completes the flow) instead of `pip install novem` + `novem --init`. Existing CLI/library configurations are still picked up automatically, so that's mentioned as the fast path for current users.
- **Profiles** section added: `novem: Login New Profile`, `novem: Select Profile`, `novem: Edit Config File`, reachable from the palette and the view `⋯` menu.
- **Working with your visuals** now covers all six resource types (plots, e-mails, grids, documents, jobs, repos — the latter two noted as appearing when the account has any), create/rename/delete via `+` and the context menu, mail _Test_ (delivers to your own address) and _Send_ (modal recipient summary before sending — matches the current `sendMail` flow), job run, repo clone.
- **Editing and previews** section added: live `novem://` filesystem (read from the API, written back on save, no local checkout), _View_ previews in an editor tab, and `nv_markdown` highlighting for content/layout/mapping files plus local `.nvm`/`.nvmd`.

## Left open

- [ ] **Imagery refresh** — `img/mail_example.png` is from 2022 (and shows an Extension Development Host window), but it still accurately illustrates tree + edit + preview, so I kept it rather than drop the only screenshot. A fresh capture needs a signed-in session with real data, so leaving that for a human with an account.

## Of note

The issue says the docs-site libraries guide "already describes the on-demand sign-in (novem-code/gaia#2804)" — it doesn't yet: that PR is still open and its current wording documents the `novem --init` prerequisite, grounded in this README's stale text. Once this merges, gaia#2804 should be updated to match (or just link here).