### PR TITLE
Maintain CHANGELOG.md on release

### DIFF
--- a/.github/workflows/vsce-release.yaml
+++ b/.github/workflows/vsce-release.yaml
@@ -54,6 +54,56 @@ jobs:
       - name: Bump package.json version
         run: npm version "$VERSION" --no-git-tag-version
 
+      - name: Update CHANGELOG.md
+        if: github.event_name == 'release'
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_DATE: ${{ github.event.release.published_at }}
+        run: |
+          set -euo pipefail
+
+          # published_at looks like 2026-07-10T12:34:56Z; keep just the date.
+          DATE="${RELEASE_DATE%%T*}"
+          if [ -z "$DATE" ]; then
+            DATE="$(date -u +%Y-%m-%d)"
+          fi
+
+          if grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "CHANGELOG.md already has an entry for $VERSION; skipping"
+            exit 0
+          fi
+
+          # Clean up GitHub's auto-generated release notes for the changelog:
+          #   - normalise CRLFs
+          #   - demote top-level "## " headings (e.g. "## What's Changed") to H3 so
+          #     they nest under the version heading
+          #   - strip the " by @user in <PR url>" attribution suffix from each line
+          # Fall back to a placeholder if there are no notes.
+          BODY="$(printf '%s' "$RELEASE_BODY" \
+            | sed 's/\r$//' \
+            | sed 's/^## /### /' \
+            | sed -E 's| by @[^ ]+ in https://[^ ]+$||')"
+          if [ -z "${BODY//[[:space:]]/}" ]; then
+            BODY="- No release notes provided."
+          fi
+
+          printf '## [%s] - %s\n\n%s\n' "$VERSION" "$DATE" "$BODY" > /tmp/new_entry.md
+
+          # Insert the new entry directly after the "## [Unreleased]" header.
+          awk '
+            /^## \[Unreleased\]/ && !inserted {
+              print
+              print ""
+              while ((getline line < "/tmp/new_entry.md") > 0) print line
+              inserted = 1
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.md.tmp
+          mv CHANGELOG.md.tmp CHANGELOG.md
+
+          echo "Updated CHANGELOG.md with $VERSION"
+
       - name: Commit version bump
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -64,7 +114,7 @@ jobs:
           # Explicitly set the remote URL with the app token
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git
 
-          git add package.json pnpm-lock.yaml
+          git add package.json pnpm-lock.yaml CHANGELOG.md
 
           if ! git diff --cached --quiet; then
             git commit -m "Release v$VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,108 @@ All notable changes to the "novem-vscode" extension will be documented in this f
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-06-08
+
+### What's Changed
+* feat: UX improvements for plot creation and tree views
+* feat: local file cache for external tool access
+* fix: propagate dark mode to webview root and react to theme toggles
+* Replace embedded login with OAuth PKCE flow
+* deps: clear some dependabot alerts, upgrade mocha and eslint
+* build(deps): bump react-router and react-router-dom
+* Migrate to pnpm + 7-day minimum release age (fixes CI)
+* preview: grids + docs, native chrome, GraphQL lists, live FS driver
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.9...v0.1.10
+
+## [0.1.9] - 2026-04-07
+
+### What's Changed
+* build(deps-dev): bump flatted from 3.3.1 to 3.4.2
+* build(deps): bump picomatch from 2.3.1 to 2.3.2
+* Update jobs/repos to /code/* paths + overdue refactors
+
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.8...v0.1.9
+
+## [0.1.8] - 2026-02-12
+
+### What's Changed
+* build(deps-dev): bump webpack from 5.96.1 to 5.105.0
+* Misc fixes
+* config: improvements
+
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.7...v0.1.8
+
+## [0.1.7] - 2026-02-03
+
+### What's Changed
+* build(deps-dev): bump glob from 10.4.5 to 10.5.0
+* build(deps): bump on-headers and compression
+* build(deps-dev): bump webpack-dev-server from 4.15.2 to 5.2.1
+* build(deps-dev): bump js-yaml from 4.1.0 to 4.1.1
+* build(deps-dev): bump http-proxy-middleware from 2.0.7 to 2.0.9
+* build(deps): bump form-data from 4.0.1 to 4.0.5
+* build(deps): bump axios from 1.7.7 to 1.12.0
+* build(deps-dev): bump node-forge from 1.3.1 to 1.3.3
+* Potential fix for code scanning alert no. 1: Workflow does not contain permissions
+* workflows: announce activity to discord
+* build(deps-dev): bump qs from 6.14.0 to 6.14.1
+* build(deps): bump @remix-run/router and react-router-dom
+* ci: bump the node version
+* build(deps-dev): bump lodash from 4.17.21 to 4.17.23
+
+### New Contributors
+* @dependabot[bot] made their first contribution in https://github.com/novem-code/novem-vscode/pull/73
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.6...v0.1.7
+
+## [0.1.6] - 2025-12-09
+
+### What's Changed
+* release: version v0.1.5
+* tree: override doctypes for certain novem-files
+* Use consistent graph icon for all plot types in sidebar
+* release: try a one-click process
+* release: try adding a github app to enable pushing through branch protections
+
+### New Contributors
+* @Copilot made their first contribution in https://github.com/novem-code/novem-vscode/pull/70
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.5...v0.1.6
+
+## [0.1.5] - 2025-11-12
+
+### What's Changed
+* bsn/release v0.1.4
+* Jobs & repos
+* Profile switching
+* Add shell.nix
+
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.4...v0.1.5
+
+## [0.1.4] - 2024-11-19
+
+### What's Changed
+* Change from novem.no to novem.io
+
+
+**Full Changelog**: https://github.com/novem-code/novem-vscode/compare/v0.1.3...v0.1.4
+
+## [0.1.3] - 2024-09-03
+
+Update marketplace banner
+
+## [0.1.2] - 2024-09-03
+
+Upgrade marketplace profile
+
+## [0.1.1] - 2024-09-02
+
+ - automate publishing to the visual studio marketplace
+
 ## [0.0.1]
 
 - Initial release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ When you have a clean `main` branch that you'd like to release:
 5. The workflow will automatically:
    - Extract version from tag
    - Bump `package.json` version
+   - Prepend the release notes to `CHANGELOG.md` under a `## [version] - date` heading
    - Commit and push changes to main
    - Publish to VS Code Marketplace
    - Send Discord notification


### PR DESCRIPTION
Closes #99.

Today changelog entries only exist on the GitHub Releases page. This wires the release workflow to keep `CHANGELOG.md` (which ships to the VS Code Marketplace changelog tab) up to date.

## What changed

**`.github/workflows/vsce-release.yaml`** — new "Update CHANGELOG.md" step (runs only on the `release` event) that:
- Inserts a `## [version] - date` section right after `## [Unreleased]` (date from `published_at`)
- Cleans up GitHub's auto-generated notes for the store audience: normalises CRLFs, demotes top-level `## ` headings (e.g. `## What's Changed`) to H3 so they nest under the version, and strips the `by @user in <PR url>` attribution suffixes
- Skips if the version already has an entry; falls back to a placeholder if the release has no notes
- The existing commit step now also stages/pushes `CHANGELOG.md` with the version bump

**`CHANGELOG.md`** — back-seeded with all historical releases (v0.1.1 → v0.1.10), newest-first, using the exact formatting the workflow now produces; original `## [0.0.1]` entry preserved.

**`RELEASE.md`** — documented the new auto-changelog step.

## Notes
- Only runs on the `release` trigger (not `workflow_dispatch`, which has no release body) — guarded by `if:`.
- The workflow mirrors whatever's in the GitHub release body, so writing a short human summary there improves both the changelog and the Marketplace listing for free.