### PR TITLE
Bump js-yaml to 4.2.0 (fix GHSA-h67p-54hq-rp68)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+
 importers:
 
   .:
@@ -714,8 +717,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1610,7 +1613,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -1680,7 +1683,7 @@ snapshots:
       he: 1.2.0
       is-path-inside: 3.0.3
       is-unicode-supported: 0.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 10.2.5
       ms: 2.1.3
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,9 @@ minimumReleaseAge: 10080
 # extension-host test runner resolves deps such as `mocha`; pnpm's default
 # symlinked layout is not resolvable there.
 nodeLinker: hoisted
+
+# Force the patched js-yaml for GHSA-h67p-54hq-rp68 (quadratic-complexity DoS
+# in merge-key handling). Only pulled in transitively by mocha (dev/test only),
+# which asks for ^4.1.0, so 4.2.0 satisfies it.
+overrides:
+  js-yaml@>=4.0.0 <=4.1.1: 4.2.0


### PR DESCRIPTION
Fixes Dependabot alert #53 (moderate).

**Vulnerability:** GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in js-yaml's merge-key handling via repeated aliases. Affects `>= 4.0.0, <= 4.1.1`; patched in 4.2.0.

**Exposure:** low — `js-yaml` is only a *transitive* dep of `mocha` (devDependency), so it's never shipped in the extension bundle; it runs only during local test config loading.

**Fix:** pinned `js-yaml` to 4.2.0 via a scoped pnpm override in `pnpm-workspace.yaml`. mocha requests `^4.1.0`, so 4.2.0 satisfies it. 4.2.0 has been public ~39 days, clearing the repo's `minimumReleaseAge` (7-day) supply-chain guard.

**Verified:** `pnpm why js-yaml` reports 4.2.0, install succeeds, and mocha still loads (`mocha --version` → 12.0.0-beta-9.4).