### PR TITLE
Remove unregistered novem.profile command declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,6 @@
         ],
         "commands": [
             {
-                "command": "novem.profile",
-                "title": "novem: Profile"
-            },
-            {
                 "command": "novem.viewNovemPlot",
                 "title": "View Plot"
             },


### PR DESCRIPTION
novem.profile was declared in contributes.commands (palette-visible)
since the initial commit but never registered via registerCommand and
never implemented. Invoking it from the Command Palette throws
"command 'novem.profile' not found" — the same class of failure as
the sendMail bug in #113, where a contributed command has no runtime
backing. Drop the dead declaration so it no longer appears.
